### PR TITLE
fix issue with findUp and git commit message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-prepare-commit-msg",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Husky Git hook to add JIRA ticket ID into the commit message",
   "author": "Dmitry Shilov",
   "bin": "./bin/index.js",
+  "files": [
+    "bin"
+  ],
   "keywords": [
     "husky",
     "jira",


### PR DESCRIPTION
I found a few errors while trying to use this package (husky v3, node v12.6+), the first was:
```
The "path" argument must be one of type string, Buffer, or URL. Received type undefined
```
This was because findUp was not choosing to locate the .git directory because the type was not specified, so I added Promise.race to get either a file or directory... I think this should work!

Then the next issue was that the message did contain the JIRA issue number because the pager I use shows the branch name. I fixed that by checking the commit message title.

~~I'm sorry that my prettier settings just took over everything...~~