### PR TITLE
Add conventional commits support

### DIFF
--- a/bin/git.js
+++ b/bin/git.js
@@ -112,7 +112,7 @@ function getJiraTicket(branchName) {
 
 function writeJiraTicket(jiraTicket) {
   debug('writeJiraTicket');
-
+  const [, , ...arguments] = process.argv;
   const messageFilePath = getMsgFilePath();
   let message;
 
@@ -124,8 +124,13 @@ function writeJiraTicket(jiraTicket) {
   }
 
   // Add jira ticket into the message in case of missing
-  if (message.indexOf(jiraTicket) < 0) {
-    message = `[${jiraTicket}]\n${message}`;
+  if (message.indexOf(jiraTicket) === -1) {
+    if (arguments.includes('--conventional-commits') && message.indexOf(':') !== -1) {
+      let [before, after] = message.split(/:(.+)/);
+      message = `${before}: [${jiraTicket}]${after}`;
+    } else {
+      message = `[${jiraTicket}]\n${message}`;
+    }
   }
 
   // Write message back to file


### PR DESCRIPTION
I am trying to enforce conventional commits using husky + commitlint but we also have a pre-receive hook stating the card ID must be present in every commit message. When trying your package to add the ID it didn't work because it is always simply prepended. I made it work using an optional command line argument.

Use `--conventional-commits` argument to place the card ID before the description in conventional commits. Which is, technically, simply after the first semicolon.

### Setup:
* Install commitlint: https://commitlint.js.org/#/guides-local-setup
* Create/update config files:
> .commitlintrc.json
```json
{
  "extends": [
    "@commitlint/config-conventional"
  ]
}
```
> .huskyrc
```json
{
  "hooks": {
    "prepare-commit-msg": "jira-prepare-commit-msg --conventional-commits",
    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
  }
}
```

### Example:
```sh
git commit -m 'test(hook): this is my commit message'
```
### Output:
```
husky > prepare-commit-msg (node v12.11.1)
JIRA prepare commit msg > start
JIRA prepare commit msg > The JIRA ticket ID is: MY-16221
JIRA prepare commit msg > done
husky > commit-msg (node v12.11.1)
[feature/MY-16221-publish-sdk 7cfa6ce] test(hook): [MY-16221] this is my commit message
 1 file changed, 1 insertion(+)
```
So the final commit message is `test(hook): [MY-16221] this is my commit message`

If there is no semicolon at all it would never be a valid conventional commit, so it will return the original message (with the card id added) which will fail if you are linting the commit message but succeed anyway otherwise. I've also tested this and verified it works with more semicolons in the commit message. 
