### PR TITLE
add the ticket code even when found in a comment

### DIFF
--- a/bin/git.js
+++ b/bin/git.js
@@ -123,9 +123,18 @@ function writeJiraTicket(jiraTicket) {
     throw new Error(`Unable to read the file "${messageFilePath}".`);
   }
 
-  // Add jira ticket into the message in case of missing
-  if (message.indexOf(jiraTicket) < 0) {
-    message = `[${jiraTicket}]\n${message}`;
+  // if the jira ticket isn't in the valid part of the message, add it to the start
+
+  // ignore everything after the scissors comment, which present when doing a --verbose commit,
+  // or `git config commit.status true`
+  const messageSections = message.split('# ------------------------ >8 ------------------------')[0];
+  const linesAboveScissors = messageSections.split('\n');
+
+  if (linesAboveScissors.every(
+    // if every line left is either commented or doesn't have the issue code
+    (line) => line.indexOf('#') === 0 || line.indexOf(jiraTicket) < 0)) {
+    // prepend the issue code to the commit message
+    message = `[${jiraTicket.toUpperCase()}] ${message}`;
   }
 
   // Write message back to file


### PR DESCRIPTION
If the Jira code is appearing in the auto-generated commit comments, for example, it shows it as part of the branch name, the hook does not add the Jira code to the commit message.

Example that will NOT have the code added to it: 
```sh

# Please enter the commit message for your changes. Lines starting  
# with '#' will be ignored, and an empty message aborts the commit. 
#                                                                   
# On branch pi-1234-test                                            
#                                                                   
# Initial commit                                                    
#                                                                   
# Changes to be committed:                                          
#       new file:   .gitignore                                      
#       new file:   .huskyrc.js                                     
#       new file:   package-lock.json                               
#       new file:   package.json                                    
#                                                                   
# Changes not staged for commit:                                    
#       modified:   .huskyrc.js                                     
#                                                                   
```

Here we check for the code existing in only uncommented lines above the commented section 'scissor block' delimiter.