### PR TITLE
Support hyphenated scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ jspm_packages/
 
 ### JetBrains template
 .idea
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.4.3
+
+- [fix] Supports hyphenated single scope as supported by conventional commit
+- [minor] Adds .DS_Store to gitignore file
+- [minor] Updates tests
+
 ### 1.4.2
 
 - [fix] Supports empty and default commit message

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-prepare-commit-msg",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2094,9 +2094,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "irregular-plurals": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-prepare-commit-msg",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Husky Git hook to add JIRA ticket ID into the commit message",
   "author": "Dmitry Shilov",
   "bin": "./bin/index.js",

--- a/src/git.ts
+++ b/src/git.ts
@@ -150,7 +150,6 @@ export function writeJiraTicket(jiraTicket: string, config: JPCMConfig): void {
     const [match, type, scope, msg] = conventionalCommitRegExp.exec(firstLine) ?? [];
     if (match) {
       debug(`Conventional commit message: ${match}`);
-      debug(`Scope: ${scope}`);
       lines[0] = `${type}${scope || ''}: ${replaceMessageByPattern(jiraTicket, msg, config.messagePattern)}`;
     }
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -5,7 +5,7 @@ import { JPCMConfig } from './config';
 import { debug } from './log';
 
 // eslint-disable-next-line max-len
-const conventionalCommitRegExp = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z ]+\)!?)?: ([\w \S]+)$/g;
+const conventionalCommitRegExp = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z- ]+\)!?)?: ([\w \S]+)$/g;
 
 function getMsgFilePath(index = 0): string {
   debug('getMsgFilePath');
@@ -150,6 +150,7 @@ export function writeJiraTicket(jiraTicket: string, config: JPCMConfig): void {
     const [match, type, scope, msg] = conventionalCommitRegExp.exec(firstLine) ?? [];
     if (match) {
       debug(`Conventional commit message: ${match}`);
+      debug(`Scope: ${scope}`);
       lines[0] = `${type}${scope || ''}: ${replaceMessageByPattern(jiraTicket, msg, config.messagePattern)}`;
     }
   }

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,6 +2,22 @@ import test, { ExecutionContext } from "ava";
 import * as path from 'path';
 import * as childProcess from 'child_process';
 
+
+interface CommitMessageToTest {
+  initialMessage: string
+  expectedMessage: string
+}
+
+const singleScopeMessage: CommitMessageToTest = {
+  initialMessage: 'chore(deps): Finally solved that problem!',
+  expectedMessage: 'chore(deps): [JIRA-4321]. Finally solved that problem!'
+}
+
+const hyphenatedScopeMessage: CommitMessageToTest = {
+  initialMessage: 'feat(new-service): Finally solved that problem!',
+  expectedMessage: 'feat(new-service): [JIRA-4321]. Finally solved that problem!'
+}
+
 function exec(cmd: string, cwd: string, t: ExecutionContext): Promise<string> {
   return new Promise((resolve, reject) => {
     console.log(`${t.title}. Exec ${cmd}`)
@@ -20,29 +36,34 @@ function exec(cmd: string, cwd: string, t: ExecutionContext): Promise<string> {
   });
 }
 
-async function steps(folder: string, t: ExecutionContext): Promise<void> {
-  const message = 'chore(deps): Finally solved that problem!';
-  const expected = 'chore(deps): [JIRA-4321]. Finally solved that problem!'
+async function testCommitMessage(commitMessageToTest: CommitMessageToTest, folder: string, t: ExecutionContext): Promise<void> {
   const cwd = path.join(__dirname, folder);
   await exec('git config user.email "you@example.com"', cwd, t);
   await exec('git config user.name "Your Name"', cwd, t);
   await exec('git add .gitignore', cwd, t);
-  await exec(`git commit -m "${message}"`, cwd, t);
+  await exec(`git commit -m "${commitMessageToTest.initialMessage}"`, cwd, t);
+
   const stdout = await exec('git log', cwd, t);
   const index = stdout.search(/(\[[A-Z]+-\d+])/i);
   t.is(index > -1, true);
-  const index2 = stdout.includes(expected);
+  const index2 = stdout.includes(commitMessageToTest.expectedMessage);
   t.is(index2, true);
 }
 
 test('husky2 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
-  await steps('husky2', t);
+  await testCommitMessage(singleScopeMessage, 'husky2', t);
+  await exec('npm run cleanup:husky:2 && npm run prepare:husky:2', './', t);
+  await testCommitMessage(hyphenatedScopeMessage, 'husky2', t);
 });
 
 test('husky3 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
-  await steps('husky3', t);
+  await testCommitMessage(singleScopeMessage, 'husky3', t);
+  await exec('npm run cleanup:husky:3 && npm run prepare:husky:3', './', t);
+  await testCommitMessage(hyphenatedScopeMessage, 'husky3', t);
 });
 
 test('husky4 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
-  await steps('husky4', t);
+  await testCommitMessage(singleScopeMessage, 'husky4', t);
+  await exec('npm run cleanup:husky:4 && npm run prepare:husky:4', './', t);
+  await testCommitMessage(hyphenatedScopeMessage, 'husky4', t);
 });


### PR DESCRIPTION
## Current Situation

The `jira-prepare-commit-msg` library supports [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/), which provides rules that are heavily inspired by [angular commits](https://gist.github.com/brianclements/841ea7bffdb01346392c). 

However, as of the released [version 1.4.2](https://www.npmjs.com/package/jira-prepare-commit-msg/v/1.4.2), [hyphenated scopes](https://gist.github.com/brianclements/841ea7bffdb01346392c#scope) are not supported. This goes against angular commit convention, which is _arguably_ [a subset](https://www.conventionalcommits.org/en/v1.0.0/#summary) of conventional commit.

Apart from the rules, the expected output of prepending the Jira ticket to [the subject](https://gist.github.com/brianclements/841ea7bffdb01346392c#subject) fails in the case of hyphenated scopes. Rather, the ticket number is just prepended to the entire commit message. This is an unexpected behaviour for a user expecting hyphenated scopes to behave as usual.

## Steps to reproduce

- In any node-based project, install [version 1.4.2](https://www.npmjs.com/package/jira-prepare-commit-msg/v/1.4.2) of this library and configure as explained in [the README.md](https://github.com/bk201-/jira-prepare-commit-msg#configuration).
- Specify the `messagePattern` as `[$J] $M`
- Run `git checkout -b JIRA-4321`
- Make a change to any file in your project.
- Run `git commit -a -m "feat(hyphenated-scope): try hyphenated scope commit message"`

Expected:

```bash
feat(hyphenated-scope): [JIRA-4321] try hyphenated scope commit message
``` 

Actual:

```bash
[JIRA-4321] feat(hyphenated-scope): try hyphenated scope commit message
``` 

## Description

This PR ensures that the expected situation is the actual result.