### PR TITLE
Make the readme command work

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For Husky 5:
 Execute command
 
 ```shell
-husky add .husky/prepare-commit-msg "npx jira-prepare-commit-msg $1"
+husky add .husky/prepare-commit-msg 'npx jira-prepare-commit-msg $1'
 ```
 
 For Husky 2-4:


### PR DESCRIPTION
Using a double quote means that bash will attempt to inject the $1 variable instead of placing it verbatim in .husky/pre-commit-msg resulting in an error.