### PR TITLE
feature: ignore branches config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ See [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for more details
     "commentChar": "#",
     "isConventionalCommit": false,
     "allowEmptyCommitMessage": false,
-    "gitRoot": ""
+    "gitRoot": "",
+    "ignoredBranchesPattern": "^$",
+    "ignoreBranchesMissingTickets": false
   }
 }
 ```
@@ -142,6 +144,30 @@ The git root folder might be set. It is either absolute path or relative path wh
 {
   "jira-prepare-commit-msg": {
     "gitRoot": "./../../"
+  }
+}
+```
+
+#### Ignoring branches
+
+Branches can be ignored and skipped by regex pattern string
+
+```json
+{
+  "jira-prepare-commit-msg": {
+    "ignoredBranchesPattern": "^main|develop|(maint-.*)$"
+  }
+}
+```
+
+#### Silently ignore any branch that does not have a jira ticket in it
+
+Be silent and skip any branch with missing jira ticket
+
+```json
+{
+  "jira-prepare-commit-msg": {
+    "ignoreBranchesMissingTickets": true
   }
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,13 @@ export type JPCMConfig = {
   isConventionalCommit: boolean; // Support https://www.conventionalcommits.org
   allowEmptyCommitMessage: boolean;
   gitRoot: string;
+  ignoredBranchesPattern: string;
+  ignoreBranchesMissingTickets: boolean;
 };
 
 const defaultConfig = {
+  ignoredBranchesPattern: '',
+  ignoreBranchesMissingTickets: false,
   messagePattern: '[$J] $M',
   jiraTicketPattern: '([A-Z]+-\\d+)',
   commentChar: '#',

--- a/src/git.ts
+++ b/src/git.ts
@@ -243,6 +243,10 @@ export function getJiraTicket(branchName: string, config: JPCMConfig): string {
   const matched = jiraIdPattern.exec(branchName);
   const jiraTicket = matched && matched[0];
 
+  if (config.ignoreBranchesMissingTickets && !jiraTicket) {
+    return '';
+  }
+
   if (!jiraTicket) {
     throw new Error('The JIRA ticket ID not found');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { error, log, debug } from './log';
 
     log(`The JIRA ticket ID is: ${ticket}`);
 
-    git.writeJiraTicket(ticket, config);
+    git.writeJiraTicket(ticket, { ...config, gitRoot });
   } catch (err: unknown) {
     if (typeof err === 'string') {
       error(err);

--- a/test/test.ts
+++ b/test/test.ts
@@ -39,6 +39,9 @@ const imitateVerboseCommit: CommitMessageToTest = {
     '# ------------------------ >8 ------------------------',
   ],
   expectedMessage: '[JIRA-4321].',
+  config: {
+    allowEmptyCommitMessage: true,
+  },
 };
 
 const conventionalCommitIncludesTicket = {
@@ -82,11 +85,17 @@ async function testCommitMessage(
   const cwd = path.join(__dirname, folder);
   await exec('git config user.email "you@example.com"', cwd, t);
   await exec('git config user.name "Your Name"', cwd, t);
-  await exec('git add .gitignore', cwd, t);
+  await exec('git add .gitignore -f', cwd, t);
 
   if (commitMessageToTest.config) {
     const pathToConfig = path.join(cwd, '.jirapreparecommitmsgrc');
-    fs.writeFileSync(pathToConfig, JSON.stringify(commitMessageToTest.config));
+    fs.writeFileSync(
+      pathToConfig,
+      JSON.stringify({
+        ...JSON.parse(fs.readFileSync(pathToConfig).toString('utf-8')),
+        ...commitMessageToTest.config,
+      }),
+    );
   }
 
   // Because I can't imitate multiline commit in Windows CLI, I decided to use file
@@ -105,7 +114,13 @@ async function testCommitMessage(
   await exec(`git update-ref -d HEAD`, cwd, t);
 }
 
-test('husky2 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
+test.serial.afterEach.always(async (t) => {
+  for (let i of [2, 3, 4, 5]) {
+    await exec(`git checkout ${path.join('.', 'husky' + i, '.jirapreparecommitmsgrc')}`, __dirname, t);
+  }
+});
+
+test.serial('husky2 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
   await testCommitMessage(singleScopeMessage, 'husky2', t);
   await testCommitMessage(hyphenatedScopeMessage, 'husky2', t);
   await testCommitMessage(firstLineWithCommentMessage, 'husky2', t);
@@ -114,7 +129,7 @@ test('husky2 JIRA ticket ID should be in commit message', async (t: ExecutionCon
   await testCommitMessage(gitRootIsSet, 'husky2', t);
 });
 
-test('husky3 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
+test.serial('husky3 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
   await testCommitMessage(singleScopeMessage, 'husky3', t);
   await testCommitMessage(hyphenatedScopeMessage, 'husky3', t);
   await testCommitMessage(firstLineWithCommentMessage, 'husky3', t);
@@ -122,8 +137,7 @@ test('husky3 JIRA ticket ID should be in commit message', async (t: ExecutionCon
   await testCommitMessage(conventionalCommitIncludesTicket, 'husky3', t);
   await testCommitMessage(gitRootIsSet, 'husky3', t);
 });
-
-test('husky4 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
+test.serial('husky4 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
   await testCommitMessage(singleScopeMessage, 'husky4', t);
   await testCommitMessage(hyphenatedScopeMessage, 'husky4', t);
   await testCommitMessage(firstLineWithCommentMessage, 'husky4', t);
@@ -131,8 +145,7 @@ test('husky4 JIRA ticket ID should be in commit message', async (t: ExecutionCon
   await testCommitMessage(conventionalCommitIncludesTicket, 'husky4', t);
   await testCommitMessage(gitRootIsSet, 'husky4', t);
 });
-
-test('husky5 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
+test.serial('husky5 JIRA ticket ID should be in commit message', async (t: ExecutionContext) => {
   await testCommitMessage(singleScopeMessage, 'husky5', t);
   await testCommitMessage(hyphenatedScopeMessage, 'husky5', t);
   await testCommitMessage(firstLineWithCommentMessage, 'husky5', t);


### PR DESCRIPTION
Just providing this upstream if you want them.

This adds two config options.
```
  ignoredBranchesPattern: string;
  ignoreBranchesMissingTickets: boolean;
```

This allows the hook to skip various scenarios without throwing an error. This also lowers some of the log messages to debug level so it makes less noise on the console.
