### PR TITLE
improve conventional commit regexp

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -13,7 +13,7 @@ interface MessageInfo {
 }
 
 const conventionalCommitRegExp =
-  /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z- ]+\)!?)?: ([\w \S]+)$/g;
+  /^([a-z]+)(\([a-z0-9-_ ]+\))?!?: ([\w \S]+)$/g;
 const gitVerboseStatusSeparator = '------------------------ >8 ------------------------';
 
 function getMsgFilePath(gitRoot: string, index = 0): string {


### PR DESCRIPTION
- Allow custom commit types.
- Allow numbers and underscores in commit scope, e.g.:

    ```
    test(e2e): change some E2E testing thing
    ```

- Fix breaking changes symbol. Previously, it didn't allow a breaking changes symbol without an scope, e.g.:

    ```
    feat!: this is a breaking change
    ```

    But now, it does.