### PR TITLE
PROPOSAL: - [feature] New config: useConventionalCommitScope

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -166,7 +166,10 @@ function insertJiraTicketIntoMessage(messageInfo: MessageInfo, jiraTicket: strin
         if (match) {
           debug(`Conventional commit message: ${match}`);
 
-          if (!msg.includes(jiraTicket)) {
+          if (config.useConventionalCommitScope && !scope?.includes(jiraTicket)) {
+            const cleanScopeUnitSet = scope ? [scope.replace(/^\(([^)]+)\)$/, "$1")] : [];
+            lines[firstLineToInsert] = `${type}(${[jiraTicket, ...cleanScopeUnitSet].join(', ')}): ${msg}`;
+          } else if (!msg.includes(jiraTicket)) {
             const replacedMessage = replaceMessageByPattern(
               jiraTicket,
               msg,


### PR DESCRIPTION
Hi @bk201-. Thank you for the valuable package which we heavily use. However according to our latest decision about commit format, we found out that `jira-prepare-commit-msg` is not flexible enough to configure that format. What we need is having Jira ticket number prepended to the conventional commit scope.
Following PR adding the additional config property `useConventionalCommitScope` which works when `isConventionalCommit` is enabled and simply prepends the number to the exisiting scope or creates one.
Consider the PR as discussion initiation if you think this is too verbose an rare case. But in my opinion it's the missing piece.
Thank you