### PR TITLE
Fixed wrong boolean check

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -10,7 +10,7 @@ export function debug(message: string): void {
 }
 
 export function log(message: string): void {
-  if (!quietLog) {
+  if (quietLog) {
     return;
   }
 


### PR DESCRIPTION
Sorry, accidentally put a `!` before the check in the last commit, which is the opposite of what is intended. Fixed it.